### PR TITLE
Bugfix: #96 온보딩 재로그인 시 취미 수정 및 게스트 토큰 처리

### DIFF
--- a/Forday/Forday/Source/Data/Network/API/Endpoint/HobbiesAPI.swift
+++ b/Forday/Forday/Source/Data/Network/API/Endpoint/HobbiesAPI.swift
@@ -24,6 +24,7 @@ enum HobbiesAPI {
     case createActivityRecord(Int)      /// 취미 활동 기록하기
 
     case fetchHobbySettings             /// 내 취미 관리 페이지 조회
+    case updateHobby(Int)               /// 온보딩 중 취미 수정 (nicknameSet: false && onboardingCompleted: true)
     case updateHobbyTime(Int)           /// 취미 시간 변경
     case updateExecutionCount(Int)      /// 실행 횟수 변경
     case updateGoalDays(Int)            /// 목표 기간 변경
@@ -73,6 +74,9 @@ enum HobbiesAPI {
 
         case .fetchHobbySettings:
             return "/hobbies/setting"
+
+        case .updateHobby(let hobbyId):
+            return "/hobbies/\(hobbyId)/update"
 
         case .updateHobbyTime(let hobbyId):
             return "/hobbies/\(hobbyId)/time"

--- a/Forday/Forday/Source/Data/Network/API/Service/ActivityService.swift
+++ b/Forday/Forday/Source/Data/Network/API/Service/ActivityService.swift
@@ -101,6 +101,11 @@ final class ActivityService {
         return try await provider.request(.fetchHobbySettings(hobbyStatus: hobbyStatus))
     }
 
+    /// 온보딩 중 취미 수정 (nicknameSet: false && onboardingCompleted: true 상태)
+    func updateHobby(hobbyId: Int, request: DTO.UpdateHobbyRequest) async throws -> DTO.UpdateHobbyDetailResponse {
+        return try await provider.request(.updateHobby(hobbyId: hobbyId, request: request))
+    }
+
     func updateHobbyTime(hobbyId: Int, request: DTO.UpdateHobbyTimeRequest) async throws -> DTO.UpdateHobbyResponse {
         return try await provider.request(.updateHobbyTime(hobbyId: hobbyId, request: request))
     }

--- a/Forday/Forday/Source/Data/Network/Base/APIConstants.swift
+++ b/Forday/Forday/Source/Data/Network/Base/APIConstants.swift
@@ -12,6 +12,7 @@ struct APIConstants {
         #if DEBUG
         // 개발 환경: 로컬 서버 사용
         #if targetEnvironment(simulator)
+//        return "http://localhost:8080"
         return "https://forday.kr"
         #else
         guard let ip = Bundle.main.infoDictionary?["LOCAL_MAC_IP"] as? String else {

--- a/Forday/Forday/Source/Data/Network/DTO/Request/Hobby/UpdateHobbyRequest.swift
+++ b/Forday/Forday/Source/Data/Network/DTO/Request/Hobby/UpdateHobbyRequest.swift
@@ -1,0 +1,34 @@
+//
+//  UpdateHobbyRequest.swift
+//  Forday
+//
+//  Created by Subeen on 2/25/26.
+//
+
+import Foundation
+
+extension DTO {
+    /// 온보딩 중 취미 수정 요청 (nicknameSet: false && onboardingCompleted: true 상태)
+    struct UpdateHobbyRequest: BaseRequest {
+        let hobbyInfoId: Int?
+        let hobbyName: String
+        let hobbyTimeMinutes: Int
+        let hobbyPurpose: String
+        let executionCount: Int
+        let durationSet: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case hobbyInfoId, hobbyName, hobbyTimeMinutes, hobbyPurpose, executionCount, durationSet
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(hobbyInfoId, forKey: .hobbyInfoId)
+            try container.encode(hobbyName, forKey: .hobbyName)
+            try container.encode(hobbyTimeMinutes, forKey: .hobbyTimeMinutes)
+            try container.encode(hobbyPurpose, forKey: .hobbyPurpose)
+            try container.encode(executionCount, forKey: .executionCount)
+            try container.encode(durationSet, forKey: .durationSet)
+        }
+    }
+}

--- a/Forday/Forday/Source/Data/Network/DTO/Response/Hobby/UpdateHobbyDetailResponse.swift
+++ b/Forday/Forday/Source/Data/Network/DTO/Response/Hobby/UpdateHobbyDetailResponse.swift
@@ -1,0 +1,27 @@
+//
+//  UpdateHobbyDetailResponse.swift
+//  Forday
+//
+//  Created by Subeen on 2/25/26.
+//
+
+import Foundation
+
+extension DTO {
+    /// 온보딩 중 취미 수정 응답 (nicknameSet: false && onboardingCompleted: true 상태)
+    struct UpdateHobbyDetailResponse: BaseResponse {
+        let status: Int
+        let success: Bool
+        let data: UpdateHobbyDetailData
+    }
+
+    struct UpdateHobbyDetailData: Codable {
+        let hobbyId: Int
+        let hobbyInfoId: Int
+        let hobbyName: String
+        let hobbyPurpose: String
+        let hobbyTimeMinutes: Int
+        let executionCount: Int
+        let goalDays: Int?  // 자율모드(durationSet: false)일 경우 null
+    }
+}

--- a/Forday/Forday/Source/Data/Network/TargetType/HobbiesTarget.swift
+++ b/Forday/Forday/Source/Data/Network/TargetType/HobbiesTarget.swift
@@ -24,6 +24,7 @@ enum HobbiesTarget {
     case deleteActivity(activityId: Int)
     case createActivityRecord(activityId: Int, request: DTO.CreateActivityRecordRequest)
     case fetchHobbySettings(hobbyStatus: String?)
+    case updateHobby(hobbyId: Int, request: DTO.UpdateHobbyRequest)
     case updateHobbyTime(hobbyId: Int, request: DTO.UpdateHobbyTimeRequest)
     case updateExecutionCount(hobbyId: Int, request: DTO.UpdateExecutionCountRequest)
     case updateGoalDays(hobbyId: Int, request: DTO.UpdateGoalDaysRequest)
@@ -77,6 +78,9 @@ extension HobbiesTarget: BaseTargetType {
         case .fetchHobbySettings:
             return HobbiesAPI.fetchHobbySettings.endpoint
 
+        case .updateHobby(let hobbyId, _):
+            return HobbiesAPI.updateHobby(hobbyId).endpoint
+
         case .updateHobbyTime(let hobbyId, _):
             return HobbiesAPI.updateHobbyTime(hobbyId).endpoint
 
@@ -124,6 +128,8 @@ extension HobbiesTarget: BaseTargetType {
             return .post
         case .fetchHobbySettings:
             return .get
+        case .updateHobby:
+            return .put
         case .updateHobbyTime:
             return .patch
         case .updateExecutionCount:
@@ -207,6 +213,9 @@ extension HobbiesTarget: BaseTargetType {
             } else {
                 return .requestPlain
             }
+
+        case .updateHobby(_, let request):
+            return .requestJSONEncodable(request)
 
         case .updateHobbyTime(_, let request):
             return .requestJSONEncodable(request)

--- a/Forday/Forday/Source/Data/Repository/HobbyRepository.swift
+++ b/Forday/Forday/Source/Data/Repository/HobbyRepository.swift
@@ -36,6 +36,28 @@ final class HobbyRepository: HobbyRepositoryInterface {
         return response.data.hobbyId
     }
 
+    func updateHobby(
+        hobbyId: Int,
+        hobbyInfoId: Int?,
+        hobbyName: String,
+        hobbyTimeMinutes: Int,
+        hobbyPurpose: String,
+        executionCount: Int,
+        isDurationSet: Bool
+    ) async throws -> Int {
+        let request = DTO.UpdateHobbyRequest(
+            hobbyInfoId: hobbyInfoId,
+            hobbyName: hobbyName,
+            hobbyTimeMinutes: hobbyTimeMinutes,
+            hobbyPurpose: hobbyPurpose,
+            executionCount: executionCount,
+            durationSet: isDurationSet
+        )
+
+        let response = try await activityService.updateHobby(hobbyId: hobbyId, request: request)
+        return response.data.hobbyId
+    }
+
     func fetchHomeInfo(hobbyId: Int?) async throws -> HomeInfo? {
         let response = try await activityService.fetchHomeInfo(hobbyId: hobbyId)
         return response.toDomain()

--- a/Forday/Forday/Source/Domain/Entity/Onboarding/OnboardingData.swift
+++ b/Forday/Forday/Source/Domain/Entity/Onboarding/OnboardingData.swift
@@ -13,4 +13,8 @@ struct OnboardingData: Codable {
     var purpose: String = ""
     var executionCount: Int = 0
     var isDurationSet: Bool = false
+
+    /// 기존 취미 ID (온보딩 재개 시 updateHobby 호출용)
+    /// nicknameSet: false && onboardingCompleted: true 상태에서 사용
+    var existingHobbyId: Int?
 }

--- a/Forday/Forday/Source/Domain/RepositoryInterface/HobbyRepositoryInterface.swift
+++ b/Forday/Forday/Source/Domain/RepositoryInterface/HobbyRepositoryInterface.swift
@@ -17,6 +17,17 @@ protocol HobbyRepositoryInterface {
         isDurationSet: Bool
     ) async throws -> Int
 
+    /// 온보딩 중 취미 수정 (nicknameSet: false && onboardingCompleted: true 상태)
+    func updateHobby(
+        hobbyId: Int,
+        hobbyInfoId: Int?,
+        hobbyName: String,
+        hobbyTimeMinutes: Int,
+        hobbyPurpose: String,
+        executionCount: Int,
+        isDurationSet: Bool
+    ) async throws -> Int
+
     func fetchHomeInfo(hobbyId: Int?) async throws -> HomeInfo?
 
     // Hobby Management

--- a/Forday/Forday/Source/Domain/UseCase/Hobby/UpdateHobbyUseCase.swift
+++ b/Forday/Forday/Source/Domain/UseCase/Hobby/UpdateHobbyUseCase.swift
@@ -1,0 +1,36 @@
+//
+//  UpdateHobbyUseCase.swift
+//  Forday
+//
+//  Created by Subeen on 2/25/26.
+//
+
+import Foundation
+
+/// 온보딩 중 취미 수정 UseCase (nicknameSet: false && onboardingCompleted: true 상태)
+final class UpdateHobbyUseCase {
+
+    private let repository: HobbyRepositoryInterface
+
+    init(repository: HobbyRepositoryInterface = HobbyRepository()) {
+        self.repository = repository
+    }
+
+    func execute(hobbyId: Int, onboardingData: OnboardingData) async throws -> Int {
+        guard let hobbyCard = onboardingData.selectedHobbyCard else {
+            throw NSError(domain: "UpdateHobbyUseCase", code: -1, userInfo: [NSLocalizedDescriptionKey: "취미 카드를 선택해주세요."])
+        }
+
+        let hobbyPurpose = onboardingData.purpose
+
+        return try await repository.updateHobby(
+            hobbyId: hobbyId,
+            hobbyInfoId: hobbyCard.id,
+            hobbyName: hobbyCard.name,
+            hobbyTimeMinutes: onboardingData.timeMinutes,
+            hobbyPurpose: hobbyPurpose,
+            executionCount: onboardingData.executionCount,
+            isDurationSet: onboardingData.isDurationSet
+        )
+    }
+}

--- a/Forday/Forday/Source/Presentation/My/Settings/GeneralSettingsViewController.swift
+++ b/Forday/Forday/Source/Presentation/My/Settings/GeneralSettingsViewController.swift
@@ -120,8 +120,8 @@ extension GeneralSettingsViewController {
 
     private func performLogout() {
         do {
-            // Delete tokens
-            try TokenStorage.shared.deleteAllTokens()
+            // Delete tokens only (guestUserId는 유지하여 재로그인 시 복원 가능)
+            try TokenStorage.shared.deleteTokens()
 
             // Delete onboarding data (optional)
             try? OnboardingDataStorage.shared.delete()

--- a/Forday/Forday/Source/Presentation/Onboarding/5. PeriodSelection/PeriodSelectionViewModel.swift
+++ b/Forday/Forday/Source/Presentation/Onboarding/5. PeriodSelection/PeriodSelectionViewModel.swift
@@ -25,11 +25,16 @@ class PeriodSelectionViewModel {
 
     // UseCase
     private let createHobbyUseCase: CreateHobbyUseCase
+    private let updateHobbyUseCase: UpdateHobbyUseCase
 
     // Initialization
 
-    init(createHobbyUseCase: CreateHobbyUseCase = CreateHobbyUseCase()) {
+    init(
+        createHobbyUseCase: CreateHobbyUseCase = CreateHobbyUseCase(),
+        updateHobbyUseCase: UpdateHobbyUseCase = UpdateHobbyUseCase()
+    ) {
         self.createHobbyUseCase = createHobbyUseCase
+        self.updateHobbyUseCase = updateHobbyUseCase
         loadMockData()
     }
     
@@ -67,14 +72,26 @@ class PeriodSelectionViewModel {
         return periods[index].id == selectedPeriod?.id
     }
 
-    /// 취미 생성 API 호출
+    /// 취미 생성 또는 수정 API 호출
+    /// - existingHobbyId가 있으면 updateHobby (온보딩 재개 시)
+    /// - existingHobbyId가 없으면 createHobby (최초 온보딩 시)
     @MainActor
     func createHobby(with onboardingData: OnboardingData) async {
         isLoading = true
         errorMessage = nil
 
         do {
-            let hobbyId = try await createHobbyUseCase.execute(onboardingData: onboardingData)
+            let hobbyId: Int
+
+            // 기존 취미 ID가 있으면 수정, 없으면 생성
+            if let existingHobbyId = onboardingData.existingHobbyId {
+                print("🔄 기존 취미 수정 - hobbyId: \(existingHobbyId)")
+                hobbyId = try await updateHobbyUseCase.execute(hobbyId: existingHobbyId, onboardingData: onboardingData)
+            } else {
+                print("🆕 새 취미 생성")
+                hobbyId = try await createHobbyUseCase.execute(onboardingData: onboardingData)
+            }
+
             isLoading = false
             AppEventBus.shared.hobbyCreated.send(hobbyId)
             onHobbyCreated?(hobbyId)
@@ -89,7 +106,7 @@ class PeriodSelectionViewModel {
             }
 
             errorMessage = error.localizedDescription
-            print("❌ 취미 생성 실패: \(error)")
+            print("❌ 취미 생성/수정 실패: \(error)")
         }
     }
 }


### PR DESCRIPTION
✨ What's this PR?                                                                                                                                                 
                                                                                                                                                                     
  📌 관련 이슈 (Related Issue)                                                                                                                                       
                                                                                                                                                                     
  - Closes #96                                                                                                                                                       
                                                                                                                                                                     
  ---                                                                                                                                                                
  🧶 주요 변경 내용 (Summary)                                                                                                                                        
                                                                                                                                                                     
  1. 게스트 로그아웃 시 guestUserId 유지                                                                                                                             
  - GeneralSettingsViewController에서 deleteAllTokens() → deleteTokens() 변경                                                                                        
  - 게스트 재로그인 시 기존 guestUserId로 로그인 가능                                                                                                                
                                                                                                                                                                     
  2. 온보딩 재개 시 취미 수정 API 연동                                                                                                                               
  - nicknameSet: false && onboardingCompleted: true 상태에서 PeriodSelection 진입 시                                                                                 
  - 기존에는 createHobby 호출 → 이제 updateHobby 호출로 변경                                                                                                         
  - PUT /hobbies/{hobbyId}/update API 연동                                                                                                                           
                                                                                                                                                                     
  3. 신규 파일                                                                                                                                                       
  - UpdateHobbyRequest.swift - 취미 수정 요청 DTO                                                                                                                    
  - UpdateHobbyDetailResponse.swift - 취미 수정 응답 DTO                                                                                                             
  - UpdateHobbyUseCase.swift - 취미 수정 UseCase                                                                                                                     
                                                                                                                                                                     
  4. 기존 파일 수정                                                                                                                                                  
  - OnboardingData - existingHobbyId 필드 추가                                                                                                                       
  - OnboardingCoordinator - 온보딩 재개 시 existingHobbyId 설정                                                                                                      
  - PeriodSelectionViewModel - existingHobbyId 유무에 따라 create/update 분기                                                                                        
                                                                                                                                                                     
  ---                                                                                                                                                                
  🧪 테스트 / 검증 내역                                                                                                                                              
                                                                                                                                                                     
  - 신규 유저 온보딩 → createHobby 정상 호출                                                                                                                         
  - 기존 유저 재로그인 (nicknameSet: false, onboardingCompleted: true) → updateHobby 정상 호출                                                                       
  - 게스트 로그아웃 후 재로그인 → guestUserId 유지되어 기존 데이터 복원                                                                                              
  - 자율모드(durationSet: false) 선택 시 goalDays: null 처리 정상                                                                                                    
                                                                                                                                                                     
  ---                                                                                                                                                                
  💬 기타 공유 사항                                                                                                                                                  
                                                                                                                                                                     
  - API 응답의 goalDays가 자율모드일 때 null로 올 수 있어 Int?로 처리                                                                                                
  - MyPageViewController의 동일한 이슈는 이전 커밋에서 수정됨                                                                                                        
                                                                                                                                                                     
  ---                                                                                                                                                                
  🙇🏻‍♀️ 리뷰 가이드 (선택)                                                                                                                                              
                                                                                                                                                                     
  - PeriodSelectionViewModel.swift의 createHobby() 메서드 분기 로직                                                                                                  
  - OnboardingCoordinator.swift의 resumeWith() 메서드에서 existingHobbyId 전달 방식  