### PR TITLE
Feature #123: 활동 반응 바텀 시트

### DIFF
--- a/Forday/Forday.xcodeproj/project.pbxproj
+++ b/Forday/Forday.xcodeproj/project.pbxproj
@@ -334,7 +334,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dayN.forday;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -377,7 +377,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.2;
+				MARKETING_VERSION = 1.1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.dayN.forday;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/Forday/Forday/Source/Data/Network/API/Endpoint/RecordsAPI.swift
+++ b/Forday/Forday/Source/Data/Network/API/Endpoint/RecordsAPI.swift
@@ -15,6 +15,8 @@ enum RecordsAPI {
     case addReaction(recordId: Int)  /// 활동 기록에 반응 추가
     case deleteReaction(recordId: Int)  /// 활동 기록 반응 삭제
     case fetchReactionUsers(recordId: Int)  /// 활동 기록에 새로 반응한 사용자 목록 조회
+    case fetchReactionSummary(recordId: Int)  /// 감정 반응 요약 및 전체 탭 데이터 조회 (v2)
+    case fetchReactionTabData(recordId: Int)  /// 특정 감정 반응 탭 페이지네이션 (v2)
     case addScrap(recordId: Int)  /// 활동 기록 스크랩 추가
     case deleteScrap(recordId: Int)  /// 활동 기록 스크랩 취소
     case reportRecord(recordId: Int)  /// 활동 기록 신고
@@ -35,6 +37,10 @@ enum RecordsAPI {
             return "/records/\(recordId)/reaction"
         case .fetchReactionUsers(let recordId):
             return "/records/\(recordId)/reaction-users"
+        case .fetchReactionSummary(let recordId):
+            return "/api/v2/records/\(recordId)/reactions/summary"
+        case .fetchReactionTabData(let recordId):
+            return "/api/v2/records/\(recordId)/reactions"
         case .addScrap(let recordId):
             return "/records/\(recordId)/scrap"
         case .deleteScrap(let recordId):

--- a/Forday/Forday/Source/Data/Network/API/Service/RecordsService.swift
+++ b/Forday/Forday/Source/Data/Network/API/Service/RecordsService.swift
@@ -75,6 +75,33 @@ final class RecordsService {
         ))
     }
 
+    // MARK: - 감정 반응 요약 및 전체 탭 데이터 조회 (v2)
+
+    /// 감정 반응 요약 및 전체 탭 데이터를 조회합니다.
+    func fetchReactionSummary(
+        recordId: Int,
+        size: Int = 20
+    ) async throws -> DTO.FetchReactionSummaryResponse {
+        return try await provider.request(.fetchReactionSummary(recordId: recordId, size: size))
+    }
+
+    // MARK: - 특정 감정 반응 탭 페이지네이션 (v2)
+
+    /// 특정 감정 반응 탭의 추가 데이터를 조회합니다.
+    func fetchReactionTabData(
+        recordId: Int,
+        reactionType: ReactionType?,
+        lastReactionId: Int,
+        size: Int = 10
+    ) async throws -> DTO.FetchReactionTabDataResponse {
+        return try await provider.request(.fetchReactionTabData(
+            recordId: recordId,
+            reactionType: reactionType,
+            lastReactionId: lastReactionId,
+            size: size
+        ))
+    }
+
     // MARK: - 활동 기록 스크랩 추가
 
     /// 활동 기록을 스크랩합니다.

--- a/Forday/Forday/Source/Data/Network/DTO/Response/Records/FetchReactionSummaryResponse.swift
+++ b/Forday/Forday/Source/Data/Network/DTO/Response/Records/FetchReactionSummaryResponse.swift
@@ -1,0 +1,117 @@
+//
+//  FetchReactionSummaryResponse.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import Foundation
+
+extension DTO {
+    struct FetchReactionSummaryResponse: BaseResponse {
+        let status: Int
+        let success: Bool
+        let data: ReactionSummaryData
+    }
+
+    struct ReactionSummaryData: Codable {
+        let reactionSummary: ReactionSummaryDTO
+        let tabs: ReactionTabsDTO
+    }
+
+    struct ReactionSummaryDTO: Codable {
+        let totalCount: Int
+        let awesome: Int
+        let great: Int
+        let amazing: Int
+        let fighting: Int
+    }
+
+    struct ReactionTabsDTO: Codable {
+        let all: ReactionTabDataDTO
+        let awesome: ReactionTabDataDTO
+        let great: ReactionTabDataDTO
+        let amazing: ReactionTabDataDTO
+        let fighting: ReactionTabDataDTO
+
+        enum CodingKeys: String, CodingKey {
+            case all = "ALL"
+            case awesome = "AWESOME"
+            case great = "GREAT"
+            case amazing = "AMAZING"
+            case fighting = "FIGHTING"
+        }
+    }
+
+    struct ReactionTabDataDTO: Codable {
+        let users: [ReactionUserItemDTO]
+        let lastReactionId: Int?
+        let hasNext: Bool
+    }
+
+    struct ReactionUserItemDTO: Codable {
+        let reactionId: Int
+        let userId: String
+        let nickname: String
+        let profileImageUrl: String?
+        let reactionType: String
+    }
+}
+
+// MARK: - Domain Mapping
+
+extension DTO.FetchReactionSummaryResponse {
+    func toDomain(recordId: Int) -> ReactionSummaryResponse {
+        return ReactionSummaryResponse(
+            recordId: recordId,
+            reactionSummary: data.reactionSummary.toDomain(),
+            tabs: data.tabs.toDomain()
+        )
+    }
+}
+
+extension DTO.ReactionSummaryDTO {
+    func toDomain() -> ReactionSummary {
+        return ReactionSummary(
+            totalCount: totalCount,
+            awesome: awesome,
+            great: great,
+            amazing: amazing,
+            fighting: fighting
+        )
+    }
+}
+
+extension DTO.ReactionTabsDTO {
+    func toDomain() -> ReactionTabs {
+        return ReactionTabs(
+            all: all.toDomain(),
+            awesome: awesome.toDomain(),
+            great: great.toDomain(),
+            amazing: amazing.toDomain(),
+            fighting: fighting.toDomain()
+        )
+    }
+}
+
+extension DTO.ReactionTabDataDTO {
+    func toDomain() -> ReactionTabData {
+        return ReactionTabData(
+            users: users.map { $0.toDomain() },
+            lastReactionId: lastReactionId,
+            hasNext: hasNext
+        )
+    }
+}
+
+extension DTO.ReactionUserItemDTO {
+    func toDomain() -> ReactionUserItem {
+        return ReactionUserItem(
+            reactionId: reactionId,
+            userId: userId,
+            nickname: nickname,
+            profileImageUrl: profileImageUrl,
+            reactionType: ReactionType(rawValue: reactionType) ?? .awesome
+        )
+    }
+}

--- a/Forday/Forday/Source/Data/Network/DTO/Response/Records/FetchReactionTabDataResponse.swift
+++ b/Forday/Forday/Source/Data/Network/DTO/Response/Records/FetchReactionTabDataResponse.swift
@@ -1,0 +1,24 @@
+//
+//  FetchReactionTabDataResponse.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import Foundation
+
+extension DTO {
+    struct FetchReactionTabDataResponse: BaseResponse {
+        let status: Int
+        let success: Bool
+        let data: ReactionTabDataDTO
+    }
+}
+
+// MARK: - Domain Mapping
+
+extension DTO.FetchReactionTabDataResponse {
+    func toDomain() -> ReactionTabData {
+        return data.toDomain()
+    }
+}

--- a/Forday/Forday/Source/Data/Network/TargetType/RecordsTarget.swift
+++ b/Forday/Forday/Source/Data/Network/TargetType/RecordsTarget.swift
@@ -17,6 +17,8 @@ enum RecordsTarget {
     case addReaction(recordId: Int, reactionType: ReactionType)
     case deleteReaction(recordId: Int, reactionType: ReactionType)
     case fetchReactionUsers(recordId: Int, reactionType: ReactionType, lastUserId: String?, size: Int)
+    case fetchReactionSummary(recordId: Int, size: Int)
+    case fetchReactionTabData(recordId: Int, reactionType: ReactionType?, lastReactionId: Int, size: Int)
     case addScrap(recordId: Int)
     case deleteScrap(recordId: Int)
     case reportRecord(recordId: Int, request: DTO.ReportRecordRequest)
@@ -40,6 +42,10 @@ extension RecordsTarget: BaseTargetType {
             return RecordsAPI.deleteReaction(recordId: recordId).endpoint
         case .fetchReactionUsers(let recordId, _, _, _):
             return RecordsAPI.fetchReactionUsers(recordId: recordId).endpoint
+        case .fetchReactionSummary(let recordId, _):
+            return RecordsAPI.fetchReactionSummary(recordId: recordId).endpoint
+        case .fetchReactionTabData(let recordId, _, _, _):
+            return RecordsAPI.fetchReactionTabData(recordId: recordId).endpoint
         case .addScrap(let recordId):
             return RecordsAPI.addScrap(recordId: recordId).endpoint
         case .deleteScrap(let recordId):
@@ -61,7 +67,7 @@ extension RecordsTarget: BaseTargetType {
             return .post
         case .deleteReaction:
             return .delete
-        case .fetchReactionUsers:
+        case .fetchReactionUsers, .fetchReactionSummary, .fetchReactionTabData:
             return .get
         case .addScrap:
             return .post
@@ -101,6 +107,25 @@ extension RecordsTarget: BaseTargetType {
 
             if let lastUserId = lastUserId {
                 parameters["lastUserId"] = lastUserId
+            }
+
+            return .requestParameters(
+                parameters: parameters,
+                encoding: URLEncoding.queryString
+            )
+        case .fetchReactionSummary(_, let size):
+            return .requestParameters(
+                parameters: ["size": size],
+                encoding: URLEncoding.queryString
+            )
+        case .fetchReactionTabData(_, let reactionType, let lastReactionId, let size):
+            var parameters: [String: Any] = [
+                "lastReactionId": lastReactionId,
+                "size": size
+            ]
+
+            if let reactionType = reactionType {
+                parameters["type"] = reactionType.rawValue
             }
 
             return .requestParameters(

--- a/Forday/Forday/Source/Data/Repository/MyPageRepository.swift
+++ b/Forday/Forday/Source/Data/Repository/MyPageRepository.swift
@@ -63,6 +63,21 @@ final class MyPageRepository: MyPageRepositoryInterface {
         return response.toDomain()
     }
 
+    func fetchReactionSummary(recordId: Int, size: Int) async throws -> ReactionSummaryResponse {
+        let response = try await recordsService.fetchReactionSummary(recordId: recordId, size: size)
+        return response.toDomain(recordId: recordId)
+    }
+
+    func fetchReactionTabData(recordId: Int, reactionType: ReactionType?, lastReactionId: Int, size: Int) async throws -> ReactionTabData {
+        let response = try await recordsService.fetchReactionTabData(
+            recordId: recordId,
+            reactionType: reactionType,
+            lastReactionId: lastReactionId,
+            size: size
+        )
+        return response.toDomain()
+    }
+
     func addScrap(recordId: Int) async throws -> ScrapResult {
         let response = try await recordsService.addScrap(recordId: recordId)
         return response.toDomain()

--- a/Forday/Forday/Source/Domain/Entity/Records/ReactionSummary.swift
+++ b/Forday/Forday/Source/Domain/Entity/Records/ReactionSummary.swift
@@ -1,0 +1,53 @@
+//
+//  ReactionSummary.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import Foundation
+
+/// 감정 반응 요약 (각 타입별 카운트)
+struct ReactionSummary {
+    let totalCount: Int
+    let awesome: Int
+    let great: Int
+    let amazing: Int
+    let fighting: Int
+
+    /// 특정 리액션 타입의 카운트 반환
+    func count(for type: ReactionType) -> Int {
+        switch type {
+        case .awesome: return awesome
+        case .great: return great
+        case .amazing: return amazing
+        case .fighting: return fighting
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+extension ReactionSummary {
+    static var preview: ReactionSummary {
+        ReactionSummary(
+            totalCount: 9,
+            awesome: 3,
+            great: 3,
+            amazing: 3,
+            fighting: 3
+        )
+    }
+
+    static var empty: ReactionSummary {
+        ReactionSummary(
+            totalCount: 0,
+            awesome: 0,
+            great: 0,
+            amazing: 0,
+            fighting: 0
+        )
+    }
+}
+#endif

--- a/Forday/Forday/Source/Domain/Entity/Records/ReactionSummaryResponse.swift
+++ b/Forday/Forday/Source/Domain/Entity/Records/ReactionSummaryResponse.swift
@@ -1,0 +1,58 @@
+//
+//  ReactionSummaryResponse.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import Foundation
+
+/// 감정 반응 목록 최초 조회 응답
+struct ReactionSummaryResponse {
+    let recordId: Int
+    let reactionSummary: ReactionSummary
+    let tabs: ReactionTabs
+}
+
+/// 전체 탭 데이터
+struct ReactionTabs {
+    let all: ReactionTabData
+    let awesome: ReactionTabData
+    let great: ReactionTabData
+    let amazing: ReactionTabData
+    let fighting: ReactionTabData
+
+    /// 특정 리액션 타입 또는 전체의 탭 데이터 반환
+    func data(for type: ReactionType?) -> ReactionTabData {
+        guard let type = type else {
+            return all
+        }
+
+        switch type {
+        case .awesome: return awesome
+        case .great: return great
+        case .amazing: return amazing
+        case .fighting: return fighting
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+extension ReactionSummaryResponse {
+    static var preview: ReactionSummaryResponse {
+        ReactionSummaryResponse(
+            recordId: 141,
+            reactionSummary: .preview,
+            tabs: ReactionTabs(
+                all: .preview,
+                awesome: .preview,
+                great: .preview,
+                amazing: .preview,
+                fighting: .preview
+            )
+        )
+    }
+}
+#endif

--- a/Forday/Forday/Source/Domain/Entity/Records/ReactionTabData.swift
+++ b/Forday/Forday/Source/Domain/Entity/Records/ReactionTabData.swift
@@ -1,0 +1,37 @@
+//
+//  ReactionTabData.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import Foundation
+
+/// 각 탭(전체, 멋져요, 짱이야 등)의 데이터
+struct ReactionTabData {
+    let users: [ReactionUserItem]
+    let lastReactionId: Int?
+    let hasNext: Bool
+}
+
+// MARK: - Preview
+
+#if DEBUG
+extension ReactionTabData {
+    static var preview: ReactionTabData {
+        ReactionTabData(
+            users: ReactionUserItem.previewList,
+            lastReactionId: 4,
+            hasNext: true
+        )
+    }
+
+    static var empty: ReactionTabData {
+        ReactionTabData(
+            users: [],
+            lastReactionId: nil,
+            hasNext: false
+        )
+    }
+}
+#endif

--- a/Forday/Forday/Source/Domain/Entity/Records/ReactionUserItem.swift
+++ b/Forday/Forday/Source/Domain/Entity/Records/ReactionUserItem.swift
@@ -1,0 +1,42 @@
+//
+//  ReactionUserItem.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import Foundation
+
+/// 감정 반응 목록 조회 API에서 사용하는 유저 정보
+struct ReactionUserItem {
+    let reactionId: Int
+    let userId: String
+    let nickname: String
+    let profileImageUrl: String?
+    let reactionType: ReactionType
+}
+
+// MARK: - Preview
+
+#if DEBUG
+extension ReactionUserItem {
+    static var preview: ReactionUserItem {
+        ReactionUserItem(
+            reactionId: 1,
+            userId: "user1",
+            nickname: "닉네임입니다",
+            profileImageUrl: nil,
+            reactionType: .awesome
+        )
+    }
+
+    static var previewList: [ReactionUserItem] {
+        [
+            ReactionUserItem(reactionId: 1, userId: "user1", nickname: "유저1", profileImageUrl: nil, reactionType: .awesome),
+            ReactionUserItem(reactionId: 2, userId: "user2", nickname: "유저2", profileImageUrl: nil, reactionType: .great),
+            ReactionUserItem(reactionId: 3, userId: "user3", nickname: "유저3", profileImageUrl: nil, reactionType: .amazing),
+            ReactionUserItem(reactionId: 4, userId: "user4", nickname: "유저4", profileImageUrl: nil, reactionType: .fighting)
+        ]
+    }
+}
+#endif

--- a/Forday/Forday/Source/Domain/RepositoryInterface/MyPageRepositoryInterface.swift
+++ b/Forday/Forday/Source/Domain/RepositoryInterface/MyPageRepositoryInterface.swift
@@ -16,6 +16,8 @@ protocol MyPageRepositoryInterface {
     func addReaction(recordId: Int, reactionType: ReactionType) async throws -> AddReactionResult
     func deleteReaction(recordId: Int, reactionType: ReactionType) async throws -> DeleteReactionResult
     func fetchReactionUsers(recordId: Int, reactionType: ReactionType, lastUserId: String?, size: Int) async throws -> FetchReactionUsersResult
+    func fetchReactionSummary(recordId: Int, size: Int) async throws -> ReactionSummaryResponse
+    func fetchReactionTabData(recordId: Int, reactionType: ReactionType?, lastReactionId: Int, size: Int) async throws -> ReactionTabData
     func addScrap(recordId: Int) async throws -> ScrapResult
     func deleteScrap(recordId: Int) async throws -> ScrapResult
 }

--- a/Forday/Forday/Source/Domain/UseCase/Records/FetchReactionSummaryUseCase.swift
+++ b/Forday/Forday/Source/Domain/UseCase/Records/FetchReactionSummaryUseCase.swift
@@ -1,0 +1,27 @@
+//
+//  FetchReactionSummaryUseCase.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import Foundation
+
+final class FetchReactionSummaryUseCase {
+
+    private let repository: MyPageRepositoryInterface
+
+    init(repository: MyPageRepositoryInterface = MyPageRepository()) {
+        self.repository = repository
+    }
+
+    func execute(
+        recordId: Int,
+        size: Int = 20
+    ) async throws -> ReactionSummaryResponse {
+        return try await repository.fetchReactionSummary(
+            recordId: recordId,
+            size: size
+        )
+    }
+}

--- a/Forday/Forday/Source/Domain/UseCase/Records/FetchReactionTabDataUseCase.swift
+++ b/Forday/Forday/Source/Domain/UseCase/Records/FetchReactionTabDataUseCase.swift
@@ -1,0 +1,31 @@
+//
+//  FetchReactionTabDataUseCase.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import Foundation
+
+final class FetchReactionTabDataUseCase {
+
+    private let repository: MyPageRepositoryInterface
+
+    init(repository: MyPageRepositoryInterface = MyPageRepository()) {
+        self.repository = repository
+    }
+
+    func execute(
+        recordId: Int,
+        reactionType: ReactionType?,
+        lastReactionId: Int,
+        size: Int = 10
+    ) async throws -> ReactionTabData {
+        return try await repository.fetchReactionTabData(
+            recordId: recordId,
+            reactionType: reactionType,
+            lastReactionId: lastReactionId,
+            size: size
+        )
+    }
+}

--- a/Forday/Forday/Source/Presentation/Common/ActivityDetail/ActivityDetailPageViewController.swift
+++ b/Forday/Forday/Source/Presentation/Common/ActivityDetail/ActivityDetailPageViewController.swift
@@ -37,7 +37,6 @@ final class ActivityDetailPageViewController: UIViewController {
     private let moreButton = UIButton()
 
     // UI Components - Bottom
-    private let reactionUsersScrollView = ReactionUsersScrollView()
     private let reactionButtonsView = ReactionButtonsView()
 
     private var cancellables = Set<AnyCancellable>()
@@ -208,18 +207,11 @@ extension ActivityDetailPageViewController {
     }
 
     private func setupReactionViews() {
-        view.addSubview(reactionUsersScrollView)
         view.addSubview(reactionButtonsView)
 
         reactionButtonsView.snp.makeConstraints {
             $0.leading.trailing.bottom.equalToSuperview()
             $0.top.equalTo(view.safeAreaLayoutGuide.snp.bottom).offset(-72)
-        }
-
-        reactionUsersScrollView.snp.makeConstraints {
-            $0.leading.trailing.equalToSuperview()
-            $0.bottom.equalTo(reactionButtonsView.snp.top)
-            $0.height.equalTo(0)
         }
 
         // 반응 버튼 이벤트 연결
@@ -233,9 +225,7 @@ extension ActivityDetailPageViewController {
 
         reactionButtonsView.reactionLongPressed
             .sink { [weak self] type in
-                Task {
-                    await self?.currentDetailVC?.viewModel.fetchReactionUsers(for: type)
-                }
+                self?.handleReactionLongPressed(type)
             }
             .store(in: &cancellables)
 
@@ -253,8 +243,6 @@ extension ActivityDetailPageViewController {
 
         // 이전 기록의 UI 상태 초기화
         saveButton.isHidden = true
-        reactionUsersScrollView.isHidden = true
-        reactionUsersScrollView.clear()
 
         guard let detailVC = currentDetailVC else { return }
 
@@ -265,28 +253,6 @@ extension ActivityDetailPageViewController {
                 guard let self = self, let detail = detail else { return }
                 self.updateNavigationState(with: detail)
                 self.reactionButtonsView.configure(with: detail)
-            }
-            .store(in: &childCancellables)
-
-        // 반응 유저 목록 업데이트
-        detailVC.viewModel.$reactionUsers
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] users in
-                guard let self = self else { return }
-
-                if users.isEmpty {
-                    self.reactionUsersScrollView.isHidden = true
-                    self.reactionUsersScrollView.clear()
-                    self.reactionUsersScrollView.snp.updateConstraints { $0.height.equalTo(0) }
-                } else {
-                    self.reactionUsersScrollView.isHidden = false
-                    self.reactionUsersScrollView.configure(with: users)
-                    self.reactionUsersScrollView.snp.updateConstraints { $0.height.equalTo(60) }
-                }
-
-                UIView.animate(withDuration: 0.3) {
-                    self.view.layoutIfNeeded()
-                }
             }
             .store(in: &childCancellables)
     }
@@ -324,6 +290,45 @@ extension ActivityDetailPageViewController {
 
     @objc private func saveButtonTapped() {
         currentDetailVC?.handleSaveButtonTapped()
+    }
+
+    private func handleReactionLongPressed(_ reactionType: ReactionType) {
+        Task { [weak self] in
+            guard let self = self, let currentDetailVC = self.currentDetailVC else { return }
+
+            do {
+                // Fetch reaction summary
+                let summary = try await currentDetailVC.viewModel.fetchReactionSummary()
+
+                await MainActor.run {
+                    // Create and present bottom sheet
+                    let bottomSheet = ReactionUsersBottomSheetViewController(recordId: currentDetailVC.viewModel.activityRecordId)
+                    bottomSheet.configure(with: summary)
+
+                    // Setup pagination callback
+                    bottomSheet.onLoadMore = { [weak currentDetailVC] reactionType, lastReactionId in
+                        guard let currentDetailVC = currentDetailVC else {
+                            return Fail(error: AppError.unknown(NSError(domain: "ViewModel", code: -1)))
+                                .eraseToAnyPublisher()
+                        }
+                        return currentDetailVC.viewModel.fetchMoreReactionUsers(
+                            for: reactionType,
+                            lastReactionId: lastReactionId
+                        )
+                    }
+
+                    self.present(bottomSheet, animated: true)
+                }
+            } catch let appError as AppError {
+                await MainActor.run {
+                    currentDetailVC.viewModel.error = appError
+                }
+            } catch {
+                await MainActor.run {
+                    currentDetailVC.viewModel.error = .unknown(error)
+                }
+            }
+        }
     }
 }
 

--- a/Forday/Forday/Source/Presentation/Common/ActivityDetail/ActivityDetailViewController.swift
+++ b/Forday/Forday/Source/Presentation/Common/ActivityDetail/ActivityDetailViewController.swift
@@ -223,28 +223,6 @@ extension ActivityDetailViewController {
                 self?.handleBookmarkTapped()
             }
             .store(in: &cancellables)
-
-        // Reaction users scroll view visibility
-        viewModel.$reactionUsers
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] users in
-                guard let self = self else { return }
-
-                if users.isEmpty {
-                    self.detailView.reactionUsersScrollView.isHidden = true
-                    self.detailView.reactionUsersScrollView.clear()
-                    self.detailView.reactionUsersScrollView.snp.updateConstraints { $0.height.equalTo(0) }
-                } else {
-                    self.detailView.reactionUsersScrollView.isHidden = false
-                    self.detailView.reactionUsersScrollView.configure(with: users)
-                    self.detailView.reactionUsersScrollView.snp.updateConstraints { $0.height.equalTo(60) }
-                }
-
-                UIView.animate(withDuration: 0.3) {
-                    self.view.layoutIfNeeded()
-                }
-            }
-            .store(in: &cancellables)
     }
 
     private func loadData() {
@@ -283,7 +261,40 @@ extension ActivityDetailViewController {
 
     private func handleReactionLongPressed(_ reactionType: ReactionType) {
         Task { [weak self] in
-            await self?.viewModel.fetchReactionUsers(for: reactionType)
+            guard let self = self else { return }
+
+            do {
+                // Fetch reaction summary
+                let summary = try await self.viewModel.fetchReactionSummary()
+
+                await MainActor.run {
+                    // Create and present bottom sheet
+                    let bottomSheet = ReactionUsersBottomSheetViewController(recordId: self.viewModel.activityRecordId)
+                    bottomSheet.configure(with: summary)
+
+                    // Setup pagination callback
+                    bottomSheet.onLoadMore = { [weak self] reactionType, lastReactionId in
+                        guard let self = self else {
+                            return Fail(error: AppError.unknown(NSError(domain: "ViewModel", code: -1)))
+                                .eraseToAnyPublisher()
+                        }
+                        return self.viewModel.fetchMoreReactionUsers(
+                            for: reactionType,
+                            lastReactionId: lastReactionId
+                        )
+                    }
+
+                    self.present(bottomSheet, animated: true)
+                }
+            } catch let appError as AppError {
+                await MainActor.run {
+                    self.viewModel.error = appError
+                }
+            } catch {
+                await MainActor.run {
+                    self.viewModel.error = .unknown(error)
+                }
+            }
         }
     }
 

--- a/Forday/Forday/Source/Presentation/Common/ActivityDetail/ActivityDetailViewModel.swift
+++ b/Forday/Forday/Source/Presentation/Common/ActivityDetail/ActivityDetailViewModel.swift
@@ -29,6 +29,8 @@ final class ActivityDetailViewModel {
     private let addReactionUseCase: AddReactionUseCase
     private let deleteReactionUseCase: DeleteReactionUseCase
     private let fetchReactionUsersUseCase: FetchReactionUsersUseCase
+    private let fetchReactionSummaryUseCase: FetchReactionSummaryUseCase
+    private let fetchReactionTabDataUseCase: FetchReactionTabDataUseCase
     private let deleteActivityRecordUseCase: DeleteActivityRecordUseCase
     private let updateHobbyCoverUseCase: UpdateHobbyCoverUseCase
     private let addScrapUseCase: AddScrapUseCase
@@ -61,6 +63,8 @@ final class ActivityDetailViewModel {
         addReactionUseCase: AddReactionUseCase = AddReactionUseCase(),
         deleteReactionUseCase: DeleteReactionUseCase = DeleteReactionUseCase(),
         fetchReactionUsersUseCase: FetchReactionUsersUseCase = FetchReactionUsersUseCase(),
+        fetchReactionSummaryUseCase: FetchReactionSummaryUseCase = FetchReactionSummaryUseCase(),
+        fetchReactionTabDataUseCase: FetchReactionTabDataUseCase = FetchReactionTabDataUseCase(),
         deleteActivityRecordUseCase: DeleteActivityRecordUseCase = DeleteActivityRecordUseCase(),
         updateHobbyCoverUseCase: UpdateHobbyCoverUseCase = UpdateHobbyCoverUseCase(),
         addScrapUseCase: AddScrapUseCase = AddScrapUseCase(),
@@ -73,6 +77,8 @@ final class ActivityDetailViewModel {
         self.addReactionUseCase = addReactionUseCase
         self.deleteReactionUseCase = deleteReactionUseCase
         self.fetchReactionUsersUseCase = fetchReactionUsersUseCase
+        self.fetchReactionSummaryUseCase = fetchReactionSummaryUseCase
+        self.fetchReactionTabDataUseCase = fetchReactionTabDataUseCase
         self.deleteActivityRecordUseCase = deleteActivityRecordUseCase
         self.updateHobbyCoverUseCase = updateHobbyCoverUseCase
         self.addScrapUseCase = addScrapUseCase
@@ -217,6 +223,45 @@ final class ActivityDetailViewModel {
             self.lastUserId = nil
             self.hasMoreUsers = true
         }
+    }
+
+    // MARK: - Reaction Summary Methods (v2)
+
+    /// 감정 반응 요약 및 전체 탭 데이터를 조회합니다.
+    func fetchReactionSummary(size: Int = 20) async throws -> ReactionSummaryResponse {
+        return try await fetchReactionSummaryUseCase.execute(
+            recordId: activityRecordId,
+            size: size
+        )
+    }
+
+    /// 특정 감정 반응 탭의 추가 데이터를 조회합니다 (페이지네이션).
+    func fetchMoreReactionUsers(
+        for reactionType: ReactionType?,
+        lastReactionId: Int,
+        size: Int = 10
+    ) -> AnyPublisher<ReactionTabData, Error> {
+        return Future<ReactionTabData, Error> { [weak self] promise in
+            guard let self = self else {
+                promise(.failure(AppError.unknown(NSError(domain: "ViewModel", code: -1))))
+                return
+            }
+
+            Task {
+                do {
+                    let result = try await self.fetchReactionTabDataUseCase.execute(
+                        recordId: self.activityRecordId,
+                        reactionType: reactionType,
+                        lastReactionId: lastReactionId,
+                        size: size
+                    )
+                    promise(.success(result))
+                } catch {
+                    promise(.failure(error))
+                }
+            }
+        }
+        .eraseToAnyPublisher()
     }
 
     // MARK: - Activity Record Actions

--- a/Forday/Forday/Source/Presentation/Common/ActivityDetail/ReactionUsersBottomSheetViewController.swift
+++ b/Forday/Forday/Source/Presentation/Common/ActivityDetail/ReactionUsersBottomSheetViewController.swift
@@ -1,0 +1,361 @@
+//
+//  ReactionUsersBottomSheetViewController.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import Combine
+
+final class ReactionUsersBottomSheetViewController: UIViewController {
+
+    // MARK: - UI Components
+
+    private let dimmerView = UIView()
+    private let containerView = UIView()
+    private let dragIndicator = UIView()
+    private let titleLabel = UILabel()
+    private let tabBar = ReactionTabBar()
+    private let pageViewController = UIPageViewController(
+        transitionStyle: .scroll,
+        navigationOrientation: .horizontal
+    )
+
+    private var listViewControllers: [ReactionUsersListViewController] = []
+
+    // MARK: - Properties
+
+    private var cancellables = Set<AnyCancellable>()
+    private let recordId: Int
+    private var summaryResponse: ReactionSummaryResponse?
+
+    // Sheet height states
+    private let minHeight: CGFloat = 322
+    private let maxHeight: CGFloat = 668
+    private var currentHeight: CGFloat = 322
+    private var containerHeightConstraint: Constraint?
+
+    // Callback for loading more users
+    var onLoadMore: ((ReactionType?, Int) -> AnyPublisher<ReactionTabData, Error>)?
+
+    // MARK: - Initialization
+
+    init(recordId: Int) {
+        self.recordId = recordId
+        super.init(nibName: nil, bundle: nil)
+        modalPresentationStyle = .overFullScreen
+        modalTransitionStyle = .crossDissolve
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupStyle()
+        setupLayout()
+        setupGestures()
+        setupBindings()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        animateIn()
+    }
+
+    // MARK: - Configuration
+
+    func configure(with response: ReactionSummaryResponse) {
+        self.summaryResponse = response
+
+        // Configure tab bar
+        tabBar.configure(with: response.reactionSummary)
+
+        // Create list view controllers for each tab
+        let tabs: [(ReactionType?, ReactionTabData)] = [
+            (nil, response.tabs.all),
+            (.awesome, response.tabs.awesome),
+            (.great, response.tabs.great),
+            (.amazing, response.tabs.amazing),
+            (.fighting, response.tabs.fighting)
+        ]
+
+        listViewControllers = tabs.map { type, data in
+            let vc = ReactionUsersListViewController(reactionType: type)
+            vc.configure(with: data)
+            vc.onLoadMore = { [weak self] reactionType, lastReactionId in
+                self?.loadMoreUsers(for: reactionType, lastReactionId: lastReactionId)
+            }
+            return vc
+        }
+
+        // Set initial page
+        if let firstVC = listViewControllers.first {
+            pageViewController.setViewControllers([firstVC], direction: .forward, animated: false)
+        }
+    }
+
+    private func loadMoreUsers(for reactionType: ReactionType?, lastReactionId: Int) {
+        guard let onLoadMore = onLoadMore else { return }
+
+        onLoadMore(reactionType, lastReactionId)
+            .receive(on: DispatchQueue.main)
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        print("❌ Failed to load more users: \(error)")
+                    }
+                },
+                receiveValue: { [weak self] tabData in
+                    guard let self = self else { return }
+
+                    // Find the index of the tab
+                    let index: Int
+                    if let type = reactionType {
+                        index = [ReactionType.awesome, .great, .amazing, .fighting].firstIndex(of: type)! + 1
+                    } else {
+                        index = 0
+                    }
+
+                    // Append new users to the corresponding list VC
+                    if index < self.listViewControllers.count {
+                        self.listViewControllers[index].appendUsers(
+                            tabData.users,
+                            lastReactionId: tabData.lastReactionId,
+                            hasNext: tabData.hasNext
+                        )
+                    }
+                }
+            )
+            .store(in: &cancellables)
+    }
+
+    // MARK: - Animations
+
+    private func animateIn() {
+        dimmerView.alpha = 0
+        containerView.transform = CGAffineTransform(translationX: 0, y: minHeight)
+
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
+            self.dimmerView.alpha = 1
+            self.containerView.transform = .identity
+        }
+    }
+
+    func dismiss() {
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseIn) {
+            self.dimmerView.alpha = 0
+            self.containerView.transform = CGAffineTransform(translationX: 0, y: self.currentHeight)
+        } completion: { _ in
+            self.dismiss(animated: false)
+        }
+    }
+
+    @objc private func dimmerTapped() {
+        dismiss()
+    }
+}
+
+// MARK: - Setup
+
+extension ReactionUsersBottomSheetViewController {
+    private func setupStyle() {
+        view.backgroundColor = .clear
+
+        dimmerView.do {
+            $0.backgroundColor = UIColor.black.withAlphaComponent(0.4)
+        }
+
+        containerView.do {
+            $0.backgroundColor = .systemBackground
+            $0.layer.cornerRadius = 20
+            $0.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
+            $0.clipsToBounds = true
+        }
+
+        dragIndicator.do {
+            $0.backgroundColor = .neutral300
+            $0.layer.cornerRadius = 2.5
+        }
+
+        titleLabel.do {
+            $0.setTextWithTypography("감정 남긴 친구 목록", style: .header18)
+            $0.textColor = .neutral900
+            $0.textAlignment = .center
+        }
+    }
+
+    private func setupLayout() {
+        view.addSubview(dimmerView)
+        view.addSubview(containerView)
+
+        containerView.addSubview(dragIndicator)
+        containerView.addSubview(titleLabel)
+        containerView.addSubview(tabBar)
+
+        addChild(pageViewController)
+        containerView.addSubview(pageViewController.view)
+        pageViewController.didMove(toParent: self)
+
+        dimmerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        containerView.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            self.containerHeightConstraint = $0.height.equalTo(minHeight).constraint
+        }
+
+        dragIndicator.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(12)
+            $0.centerX.equalToSuperview()
+            $0.width.equalTo(36)
+            $0.height.equalTo(5)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(dragIndicator.snp.bottom).offset(16)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+
+        tabBar.snp.makeConstraints {
+            $0.top.equalTo(titleLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(40)
+        }
+
+        pageViewController.view.snp.makeConstraints {
+            $0.top.equalTo(tabBar.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalToSuperview().offset(-34)  // Home indicator space
+        }
+    }
+
+    private func setupGestures() {
+        // Dimmer tap gesture
+        let dimmerTap = UITapGestureRecognizer(target: self, action: #selector(dimmerTapped))
+        dimmerView.addGestureRecognizer(dimmerTap)
+
+        // Pan gesture for dragging
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+        panGesture.delegate = self
+        containerView.addGestureRecognizer(panGesture)
+    }
+
+    private func setupBindings() {
+        // Tab selection
+        tabBar.tabSelected
+            .sink { [weak self] index in
+                guard let self = self,
+                      index < self.listViewControllers.count,
+                      let currentVC = self.pageViewController.viewControllers?.first,
+                      let currentIndex = self.listViewControllers.firstIndex(of: currentVC as! ReactionUsersListViewController)
+                else { return }
+
+                let direction: UIPageViewController.NavigationDirection = index > currentIndex ? .forward : .reverse
+                let targetVC = self.listViewControllers[index]
+
+                self.pageViewController.setViewControllers([targetVC], direction: direction, animated: true)
+            }
+            .store(in: &cancellables)
+
+        // Page view controller delegate
+        pageViewController.delegate = self
+        pageViewController.dataSource = self
+    }
+
+    @objc private func handlePan(_ gesture: UIPanGestureRecognizer) {
+        let translation = gesture.translation(in: view)
+        let velocity = gesture.velocity(in: view)
+
+        switch gesture.state {
+        case .changed:
+            // Update height based on drag
+            let newHeight = currentHeight - translation.y
+            let clampedHeight = max(minHeight, min(maxHeight, newHeight))
+            containerHeightConstraint?.update(offset: clampedHeight)
+            gesture.setTranslation(.zero, in: view)
+
+        case .ended:
+            // Snap to closest state
+            let targetHeight: CGFloat
+            if velocity.y < -500 {
+                // Fast upward swipe -> expand
+                targetHeight = maxHeight
+            } else if velocity.y > 500 {
+                // Fast downward swipe -> collapse or dismiss
+                targetHeight = currentHeight < (minHeight + maxHeight) / 2 ? 0 : minHeight
+            } else {
+                // Slow drag -> snap to nearest
+                let midpoint = (minHeight + maxHeight) / 2
+                targetHeight = currentHeight > midpoint ? maxHeight : minHeight
+            }
+
+            if targetHeight == 0 {
+                dismiss()
+            } else {
+                animateToHeight(targetHeight)
+            }
+
+        default:
+            break
+        }
+    }
+
+    private func animateToHeight(_ height: CGFloat) {
+        currentHeight = height
+        containerHeightConstraint?.update(offset: height)
+
+        UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 0.8, initialSpringVelocity: 0) {
+            self.view.layoutIfNeeded()
+        }
+    }
+}
+
+// MARK: - UIPageViewControllerDelegate, UIPageViewControllerDataSource
+
+extension ReactionUsersBottomSheetViewController: UIPageViewControllerDelegate, UIPageViewControllerDataSource {
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        guard let currentVC = viewController as? ReactionUsersListViewController,
+              let currentIndex = listViewControllers.firstIndex(of: currentVC),
+              currentIndex > 0 else {
+            return nil
+        }
+        return listViewControllers[currentIndex - 1]
+    }
+
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        guard let currentVC = viewController as? ReactionUsersListViewController,
+              let currentIndex = listViewControllers.firstIndex(of: currentVC),
+              currentIndex < listViewControllers.count - 1 else {
+            return nil
+        }
+        return listViewControllers[currentIndex + 1]
+    }
+
+    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+        guard completed,
+              let currentVC = pageViewController.viewControllers?.first as? ReactionUsersListViewController,
+              let currentIndex = listViewControllers.firstIndex(of: currentVC) else {
+            return
+        }
+
+        // Update tab bar selection
+        tabBar.selectTab(at: currentIndex)
+    }
+}
+
+// MARK: - UIGestureRecognizerDelegate
+
+extension ReactionUsersBottomSheetViewController: UIGestureRecognizerDelegate {
+    func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        // Allow pan gesture and scroll view gestures to work together
+        return true
+    }
+}

--- a/Forday/Forday/Source/Presentation/Common/ActivityDetail/View/ReactionTabBar.swift
+++ b/Forday/Forday/Source/Presentation/Common/ActivityDetail/View/ReactionTabBar.swift
@@ -1,0 +1,271 @@
+//
+//  ReactionTabBar.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import Combine
+
+/// 감정 반응 바텀시트의 커스텀 탭 바
+final class ReactionTabBar: UIView {
+
+    // MARK: - UI Components
+
+    private let scrollView = UIScrollView()
+    private let stackView = UIStackView()
+    private let bottomBorder = UIView()
+
+    private var tabButtons: [ReactionTabButton] = []
+
+    // MARK: - Properties
+
+    private var selectedIndex: Int = 0
+    let tabSelected = PassthroughSubject<Int, Never>()
+
+    // MARK: - Initialization
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupStyle()
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Configuration
+
+    /// 탭 바 구성 (전체, 멋져요, 짱이야, 대단해, 화이팅)
+    func configure(with summary: ReactionSummary) {
+        // Clear existing tabs
+        tabButtons.forEach { $0.removeFromSuperview() }
+        tabButtons.removeAll()
+        stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+
+        // Add tab buttons
+        let tabs: [(title: String, count: Int, icon: UIImage?)] = [
+            ("전체", summary.totalCount, nil),
+            ("", summary.awesome, .Reaction.awesome),
+            ("", summary.great, .Reaction.great),
+            ("", summary.amazing, .Reaction.amazing),
+            ("", summary.fighting, .Reaction.fighting)
+        ]
+
+        for (index, tab) in tabs.enumerated() {
+            let button = ReactionTabButton(
+                title: tab.title,
+                count: tab.count,
+                icon: tab.icon,
+                isSelected: index == 0
+            )
+            button.tag = index
+            button.addTarget(self, action: #selector(tabButtonTapped(_:)), for: .touchUpInside)
+
+            stackView.addArrangedSubview(button)
+            tabButtons.append(button)
+        }
+
+        // Select first tab by default
+        selectedIndex = 0
+    }
+
+    func selectTab(at index: Int) {
+        guard index != selectedIndex, index < tabButtons.count else { return }
+
+        tabButtons[selectedIndex].setSelected(false)
+        tabButtons[index].setSelected(true)
+        selectedIndex = index
+    }
+
+    @objc private func tabButtonTapped(_ sender: UIButton) {
+        let index = sender.tag
+        guard index != selectedIndex else { return }
+
+        selectTab(at: index)
+        tabSelected.send(index)
+    }
+}
+
+// MARK: - Setup
+
+extension ReactionTabBar {
+    private func setupStyle() {
+        backgroundColor = .clear
+
+        scrollView.do {
+            $0.showsHorizontalScrollIndicator = false
+            $0.showsVerticalScrollIndicator = false
+        }
+
+        stackView.do {
+            $0.axis = .horizontal
+            $0.spacing = 0
+            $0.alignment = .fill
+            $0.distribution = .fillProportionally
+        }
+
+        bottomBorder.do {
+            $0.backgroundColor = .stroke001
+        }
+    }
+
+    private func setupLayout() {
+        addSubview(scrollView)
+        addSubview(bottomBorder)
+        scrollView.addSubview(stackView)
+
+        scrollView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        stackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+            $0.height.equalToSuperview()
+        }
+
+        bottomBorder.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+    }
+}
+
+// MARK: - ReactionTabButton
+
+private final class ReactionTabButton: UIButton {
+
+    // MARK: - UI Components
+
+    private let iconImageView = UIImageView()
+    private let countLabel = UILabel()
+    private let bottomIndicator = UIView()
+
+    // MARK: - Properties
+
+    private let icon: UIImage?
+    private let count: Int
+
+    // MARK: - Initialization
+
+    init(title: String, count: Int, icon: UIImage?, isSelected: Bool) {
+        self.icon = icon
+        self.count = count
+        super.init(frame: .zero)
+
+        setupStyle()
+        setupLayout()
+        configure(title: title, count: count, icon: icon)
+        setSelected(isSelected)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Configuration
+
+    private func configure(title: String, count: Int, icon: UIImage?) {
+        if let icon = icon {
+            // Icon tab
+            iconImageView.image = icon
+            iconImageView.isHidden = false
+            setTitle(nil, for: .normal)
+        } else {
+            // Text tab (전체)
+            iconImageView.isHidden = true
+            let attributedTitle = NSAttributedString(
+                string: title,
+                attributes: TypographyStyle.body14.attributes
+            )
+            setAttributedTitle(attributedTitle, for: .normal)
+        }
+
+        countLabel.setTextWithTypography("\(count)", style: .label14)
+    }
+
+    func setSelected(_ selected: Bool) {
+        if icon != nil {
+            // Icon tab
+            iconImageView.tintColor = selected ? .neutral800 : .neutral400
+            countLabel.textColor = selected ? .neutral800 : .neutral400
+        } else {
+            // Text tab
+            if let currentTitle = attributedTitle(for: .normal)?.string ?? titleLabel?.text {
+                let style: TypographyStyle = selected ? .body14 : .label14
+                var attributes = style.attributes
+                attributes[.foregroundColor] = selected ? UIColor.neutral800 : UIColor.neutral400
+
+                let attributedTitle = NSAttributedString(
+                    string: currentTitle,
+                    attributes: attributes
+                )
+                setAttributedTitle(attributedTitle, for: .normal)
+            }
+            countLabel.textColor = selected ? .neutral800 : .neutral400
+        }
+
+        bottomIndicator.isHidden = !selected
+    }
+
+    private func setupStyle() {
+        backgroundColor = .clear
+
+        iconImageView.do {
+            $0.contentMode = .scaleAspectFit
+            $0.isHidden = true
+        }
+
+        countLabel.do {
+            $0.textColor = .neutral400
+        }
+
+        bottomIndicator.do {
+            $0.backgroundColor = .neutral800
+            $0.isHidden = true
+        }
+    }
+
+    private func setupLayout() {
+        let containerView = UIView()
+        addSubview(containerView)
+        addSubview(bottomIndicator)
+
+        containerView.addSubview(iconImageView)
+        containerView.addSubview(countLabel)
+
+        containerView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.top.greaterThanOrEqualToSuperview().offset(8)
+            $0.bottom.lessThanOrEqualTo(bottomIndicator.snp.top).offset(-8)
+        }
+
+        // Icon tab layout
+        iconImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(16)
+        }
+
+        countLabel.snp.makeConstraints {
+            $0.leading.equalTo(iconImageView.snp.trailing).offset(4)
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalToSuperview()
+        }
+
+        bottomIndicator.snp.makeConstraints {
+            $0.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalTo(2)
+        }
+
+        // Set button size
+        self.snp.makeConstraints {
+            $0.width.greaterThanOrEqualTo(50)
+            $0.height.equalTo(40)
+        }
+    }
+}

--- a/Forday/Forday/Source/Presentation/Common/ActivityDetail/View/ReactionUserListCell.swift
+++ b/Forday/Forday/Source/Presentation/Common/ActivityDetail/View/ReactionUserListCell.swift
@@ -1,0 +1,112 @@
+//
+//  ReactionUserListCell.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import Kingfisher
+
+final class ReactionUserListCell: UITableViewCell {
+
+    // MARK: - UI Components
+
+    private let profileImageView = UIImageView()
+    private let nicknameLabel = UILabel()
+    private let reactionIconContainer = UIView()
+    private let reactionIconImageView = UIImageView()
+
+    // MARK: - Initialization
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupStyle()
+        setupLayout()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Configuration
+
+    func configure(with item: ReactionUserItem) {
+        nicknameLabel.setTextWithTypography(item.nickname, style: .body14)
+        profileImageView.setImage(with: item.profileImageUrl)
+        reactionIconImageView.image = item.reactionType.icon
+    }
+}
+
+// MARK: - Setup
+
+extension ReactionUserListCell {
+    private func setupStyle() {
+        selectionStyle = .none
+        backgroundColor = .clear
+
+        profileImageView.do {
+            $0.contentMode = .scaleAspectFill
+            $0.clipsToBounds = true
+            $0.layer.cornerRadius = 18  // 36pt / 2
+            $0.backgroundColor = .bg003
+        }
+
+        nicknameLabel.do {
+            $0.textColor = .neutral800
+        }
+
+        reactionIconContainer.do {
+            $0.backgroundColor = .primary002  // #FFE6D1
+            $0.layer.borderWidth = 1
+            $0.layer.borderColor = UIColor.action001.cgColor  // #FF9447
+            $0.layer.cornerRadius = 12  // 24pt / 2
+            $0.clipsToBounds = true
+        }
+
+        reactionIconImageView.do {
+            $0.contentMode = .scaleAspectFit
+        }
+    }
+
+    private func setupLayout() {
+        contentView.addSubview(profileImageView)
+        contentView.addSubview(nicknameLabel)
+        contentView.addSubview(reactionIconContainer)
+        reactionIconContainer.addSubview(reactionIconImageView)
+
+        profileImageView.snp.makeConstraints {
+            $0.leading.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(36)
+        }
+
+        nicknameLabel.snp.makeConstraints {
+            $0.leading.equalTo(profileImageView.snp.trailing).offset(16)
+            $0.centerY.equalToSuperview()
+            $0.trailing.lessThanOrEqualTo(reactionIconContainer.snp.leading).offset(-16)
+        }
+
+        reactionIconContainer.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalToSuperview()
+            $0.size.equalTo(24)
+        }
+
+        reactionIconImageView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.size.equalTo(16)
+        }
+    }
+}
+
+#if DEBUG
+#Preview("ReactionUserListCell") {
+    let cell = ReactionUserListCell()
+    cell.configure(with: .preview)
+    cell.frame = CGRect(x: 0, y: 0, width: 320, height: 44)
+    return cell
+}
+#endif

--- a/Forday/Forday/Source/Presentation/Common/ActivityDetail/View/ReactionUsersListViewController.swift
+++ b/Forday/Forday/Source/Presentation/Common/ActivityDetail/View/ReactionUsersListViewController.swift
@@ -1,0 +1,147 @@
+//
+//  ReactionUsersListViewController.swift
+//  Forday
+//
+//  Created by Subeen on 4/7/26.
+//
+
+import UIKit
+import SnapKit
+import Then
+import Combine
+
+/// 특정 리액션 타입 또는 전체의 유저 목록을 표시하는 ViewController
+final class ReactionUsersListViewController: UIViewController {
+
+    // MARK: - UI Components
+
+    private let tableView = UITableView()
+    private let emptyLabel = UILabel()
+
+    // MARK: - Properties
+
+    private let reactionType: ReactionType?  // nil이면 전체
+    private var users: [ReactionUserItem] = []
+    private var lastReactionId: Int?
+    private var hasNext: Bool = false
+    private var isLoadingMore = false
+
+    var onLoadMore: ((ReactionType?, Int) -> Void)?
+
+    // MARK: - Initialization
+
+    init(reactionType: ReactionType?) {
+        self.reactionType = reactionType
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupStyle()
+        setupLayout()
+        setupTableView()
+    }
+
+    // MARK: - Configuration
+
+    func configure(with tabData: ReactionTabData) {
+        self.users = tabData.users
+        self.lastReactionId = tabData.lastReactionId
+        self.hasNext = tabData.hasNext
+
+        updateEmptyState()
+        tableView.reloadData()
+    }
+
+    func appendUsers(_ newUsers: [ReactionUserItem], lastReactionId: Int?, hasNext: Bool) {
+        self.users.append(contentsOf: newUsers)
+        self.lastReactionId = lastReactionId
+        self.hasNext = hasNext
+        self.isLoadingMore = false
+
+        tableView.reloadData()
+    }
+
+    private func updateEmptyState() {
+        emptyLabel.isHidden = !users.isEmpty
+        tableView.isHidden = users.isEmpty
+    }
+}
+
+// MARK: - Setup
+
+extension ReactionUsersListViewController {
+    private func setupStyle() {
+        view.backgroundColor = .systemBackground
+
+        emptyLabel.do {
+            $0.setTextWithTypography("아직 감정 표현이 없어요", style: .label14, alignment: .center)
+            $0.textColor = .neutral400
+            $0.isHidden = true
+        }
+    }
+
+    private func setupLayout() {
+        view.addSubview(tableView)
+        view.addSubview(emptyLabel)
+
+        tableView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+
+        emptyLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+
+    private func setupTableView() {
+        tableView.do {
+            $0.delegate = self
+            $0.dataSource = self
+            $0.register(ReactionUserListCell.self, forCellReuseIdentifier: "ReactionUserListCell")
+            $0.separatorStyle = .none
+            $0.backgroundColor = .clear
+            $0.rowHeight = 44
+            $0.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 20, right: 0)
+        }
+    }
+}
+
+// MARK: - UITableViewDelegate, UITableViewDataSource
+
+extension ReactionUsersListViewController: UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return users.count
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "ReactionUserListCell", for: indexPath) as? ReactionUserListCell else {
+            return UITableViewCell()
+        }
+
+        let user = users[indexPath.row]
+        cell.configure(with: user)
+        return cell
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard hasNext, !isLoadingMore else { return }
+
+        let offsetY = scrollView.contentOffset.y
+        let contentHeight = scrollView.contentSize.height
+        let frameHeight = scrollView.frame.height
+
+        // 바닥에서 100pt 전에 다음 페이지 로드
+        if offsetY > contentHeight - frameHeight - 100 {
+            guard let lastReactionId = lastReactionId else { return }
+            isLoadingMore = true
+            onLoadMore?(reactionType, lastReactionId)
+        }
+    }
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feat: #123 활동 기록 감정 표현 사용자 목록 조회 구현
-->

## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #123

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- **감정 표현(Reaction) 사용자 목록 조회 기능 구현**
  - 활동 기록 상세 화면에서 감정 표현 버튼 롱프레스 시 사용자 목록 바텀시트 노출 (ReactionUsersBottomSheetViewController)
  - 감정 종류별(전체, 축하, 응원 등) 탭 전환 및 사용자 리스트 페이징 처리
  - 커스텀 탭바 구현 (ReactionTabBar) 및 사용자 셀 디자인 (ReactionUserListCell)
- **도메인 및 데이터 레이어 확장**
  - 감정 표현 요약 및 탭별 데이터 조회를 위한 UseCase 추가 (FetchReactionSummaryUseCase, FetchReactionTabDataUseCase)
  - RecordsAPI 및 RecordsService 내 반응 관련 엔드포인트 연동
  - 반응 관련 Entity 및 DTO 정의 (ReactionSummary, ReactionUserItem 등)
- **활동 상세 화면 고도화**
  - ActivityDetailViewModel 내 반응 목록 조회를 위한 상태 관리 및 바인딩 로직 보강
  - 상세 화면 내 레이아웃 및 인터랙션 개선
- **(기존 포함) 알림 및 설정 기능**
  - 알림 목록 조회, 읽음 처리 및 설정 기능 포함
  - FCM 푸시 알림 인프라 및 설정 화면 리팩토링 포함

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->

| 반응 사용자 목록 (바텀시트) | 감정 탭 전환 | 상세 화면 인터랙션 |
|------|-------|-------|
| <img width="300" alt="반응목록" src=""> | <img width="300" alt="탭전환" src=""> | <img width="300" alt="상세인터랙션" src=""> |

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상 동작 확인
- [x] 반응 버튼 롱프레스 시 바텀시트 정상 노출 확인
- [x] 감정 탭별 사용자 목록 API 연동 및 전환 확인
- [x] 사용자 리스트 스크롤 시 페이징 처리 확인
- [x] 알림 및 설정 화면 기존 기능 정상 동작 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- ReactionUsersBottomSheet에서 탭 전환 시 상단 감정별 카운트가 실시간 반영되도록 처리했습니다.
- 롱프레스 인터랙션(UILongPressGestureRecognizer) 시 바텀시트 트리거 시점을 조정했습니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- ReactionTabBar.swift의 커스텀 탭 디자인 및 애니메이션 구현 방식
- ReactionUsersBottomSheetViewController에서의 상태 관리 및 데이터 바인딩 로직
- RecordsTarget 및 RecordsAPI의 반응 관련 엔드포인트 구성


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 반응(reaction) 요약 정보를 탭 기반 네비게이션으로 표시하는 기능 추가
  * 반응별 사용자 목록을 스크롤 가능한 바텀시트로 표시하는 기능 추가
  * 각 반응 탭에 대한 무한 스크롤 페이지네이션 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->